### PR TITLE
Avoid using data class when not necessary

### DIFF
--- a/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/MocksTracker.kt
+++ b/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/MocksTracker.kt
@@ -17,5 +17,5 @@ object MocksTracker {
         getMocks(testInstance).map{it.mock}.forEach(::clearMocks)
     }
 
-    data class Mocked(val mock: Any, val beanInstance: Any)
+    class Mocked(val mock: Any, val beanInstance: Any)
 }


### PR DESCRIPTION
this avoid computing the hashcode of the beaninstance in the mockTracker

close https://github.com/quarkusio/quarkus/issues/25095