### PR TITLE
Update mockk from 1.12.4 to 1.13.4

### DIFF
--- a/junit5-mockk/pom.xml
+++ b/junit5-mockk/pom.xml
@@ -9,14 +9,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>io.quarkiverse.mockk</groupId>
     <artifactId>quarkus-junit5-mockk</artifactId>
     <name>Quarkus - JUnit 5 - Mockk</name>
 
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
@@ -34,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
+            <artifactId>mockk-jvm</artifactId>
             <version>${mockk.version}</version>
         </dependency>
         <dependency>

--- a/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/CreateMockkSpiesCallback.kt
+++ b/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/CreateMockkSpiesCallback.kt
@@ -2,7 +2,7 @@ package io.quarkiverse.test.junit.mockk.internal
 
 import io.mockk.spyk
 import io.quarkiverse.test.junit.mockk.InjectSpy
-import io.quarkus.arc.runtime.ClientProxyUnwrapper
+import io.quarkus.arc.ClientProxy
 import io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback
 import java.lang.reflect.Field
 
@@ -24,8 +24,7 @@ class CreateMockkSpiesCallback: QuarkusTestAfterConstructCallback {
     }
 
     private fun createSpyAndSetTestField(testInstance: Any, field: Field, beanInstance: Any): Any {
-        val unwrapper = ClientProxyUnwrapper()
-        val spy = spyk(unwrapper.apply(beanInstance))
+        val spy = spyk(ClientProxy.unwrap(beanInstance))
         if (field.trySetAccessible()) {
             field.set(testInstance, spy)
         }

--- a/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.kt
+++ b/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.kt
@@ -5,7 +5,6 @@ import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem
 import io.quarkus.arc.processor.AnnotationsTransformer
 import io.quarkus.arc.processor.DotNames
 import io.quarkus.builder.BuildChainBuilder
-import io.quarkus.builder.BuildStep
 import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer
 import org.jboss.jandex.AnnotationTarget
 import org.jboss.jandex.AnnotationValue
@@ -20,9 +19,9 @@ class SingletonToApplicationScopedTestBuildChainCustomizerProducer: TestBuildCha
         val INJECT_MOCK: DotName = DotName.createSimple(InjectMock::class.java.name)
     }
 
-    override fun produce(testClassesIndex: Index): Consumer<BuildChainBuilder?>? = Consumer { buildChainBuilder ->
-        buildChainBuilder?.let {it.addBuildStep(BuildStep { context ->
-            val mockTypes = testClassesIndex?.getAnnotations(INJECT_MOCK)
+    override fun produce(testClassesIndex: Index): Consumer<BuildChainBuilder?> = Consumer { buildChainBuilder ->
+        buildChainBuilder?.let { buildChainBuilder.addBuildStep { context ->
+            val mockTypes = testClassesIndex.getAnnotations(INJECT_MOCK)
                 ?.filter { it.target().kind() == AnnotationTarget.Kind.FIELD }
                 ?.filter {
                     val allowScopeConversionValue = it.value("convertScopes")
@@ -41,7 +40,7 @@ class SingletonToApplicationScopedTestBuildChainCustomizerProducer: TestBuildCha
                         if (target.kind() == AnnotationTarget.Kind.CLASS) { // scope on bean case
                             val classInfo = target.asClass()
                             if (isMatchingBean(classInfo)) {
-                                if (classInfo.classAnnotation(DotNames.SINGLETON) != null) {
+                                if (classInfo.declaredAnnotation(DotNames.SINGLETON) != null) {
                                     replaceSingletonWithApplicationScoped(transformationContext)
                                 }
                             }
@@ -84,6 +83,7 @@ class SingletonToApplicationScopedTestBuildChainCustomizerProducer: TestBuildCha
                     }
                 }))
             }
-        })}?.produces(AnnotationsTransformerBuildItem::class.java)?.build()
+        }
+        }?.produces(AnnotationsTransformerBuildItem::class.java)?.build()
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <name>Quarkus - JUnit 5 - Mockk Parent</name>
 
     <properties>
-        <kotlin.version>1.8.0</kotlin.version>
-        <mockk.version>1.12.4</mockk.version>
+        <kotlin.version>1.8.10</kotlin.version>
+        <mockk.version>1.13.4</mockk.version>
 
         <quarkus.version>2.16.0.Final</quarkus.version>
         <dokka.version>1.7.20</dokka.version>


### PR DESCRIPTION
### Changes
- Remove deprecated code
- Upgrade Kotlin from 1.18.0 to 1.18.10 and targets JDK 11+
- Upgrade Mockk from 1.12.4 to 1.13.4