### PR TITLE
Remove usage of deprecated field

### DIFF
--- a/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/CreateMockkSpiesCallback.kt
+++ b/junit5-mockk/src/main/kotlin/io/quarkiverse/test/junit/mockk/internal/CreateMockkSpiesCallback.kt
@@ -2,7 +2,7 @@ package io.quarkiverse.test.junit.mockk.internal
 
 import io.mockk.spyk
 import io.quarkiverse.test.junit.mockk.InjectSpy
-import io.quarkus.arc.runtime.ClientProxyUnwrapper
+import io.quarkus.arc.ClientProxy
 import io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback
 import java.lang.reflect.Field
 
@@ -24,8 +24,7 @@ class CreateMockkSpiesCallback: QuarkusTestAfterConstructCallback {
     }
 
     private fun createSpyAndSetTestField(testInstance: Any, field: Field, beanInstance: Any): Any {
-        val unwrapper = ClientProxyUnwrapper()
-        val spy = spyk(unwrapper.apply(beanInstance))
+        val spy = spyk(ClientProxy.unwrap(beanInstance))
         if (field.trySetAccessible()) {
             field.set(testInstance, spy)
         }


### PR DESCRIPTION
`ClientProxyUnwrapper` is currently deprecated and removed in more recent Quarkus version so I've removed it usage.

This is currently blocking the update to Quarkus 3.2.3.Final