### PR TITLE
Fix version highlights in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependencies {
 
 ## Compatibility with Quarkus
 
-Starting with version ˋ3+`, version `2.0.0` of `quarkus-junit5-mockk` should be used.
+Starting with version `3+`, version `2.0.0` of `quarkus-junit5-mockk` should be used.
 If you use a version between `2.8` and before `3.0.0`, version `1.1.0` of `quarkus-junit5-mockk` should be used.
 If you use a version before `2.7`, version `1.0.1` of `quarkus-junit5-mockk` should be used.
 


### PR DESCRIPTION
The first back tick was wrong leading to a broken styling of the readme. 