### PR TITLE
chore(deps): add github actions to the dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The github actions in the workflow files are severely outdated. Added checks for the github-actions package ecosystem in dependabot configuration to help keep the actions up to date