### PR TITLE
chore(deps): upgrade to jdk 17 and latest quarkus lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ dependencies {
 
 ## Compatibility with Quarkus
 
-Starting with version `3+`, version `2.0.0` of `quarkus-junit5-mockk` should be used.
+Starting with version `3.8+`, version `3+` of `quarkus-junit5-mockk` should be used.
+If you use a version between ˋ3.0.0`, and before `3.8.0`, version `2.0.0` of `quarkus-junit5-mockk` should be used.
 If you use a version between `2.8` and before `3.0.0`, version `1.1.0` of `quarkus-junit5-mockk` should be used.
 If you use a version before `2.7`, version `1.0.1` of `quarkus-junit5-mockk` should be used.
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.mockk</groupId>
         <artifactId>quarkus-junit5-mockk-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/junit5-mockk/pom.xml
+++ b/junit5-mockk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.mockk</groupId>
         <artifactId>quarkus-junit5-mockk-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,19 +11,19 @@
     <groupId>io.quarkiverse.mockk</groupId>
     <artifactId>quarkus-junit5-mockk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>Quarkus - JUnit 5 - Mockk Parent</name>
 
     <properties>
         <kotlin.version>1.9.22</kotlin.version>
         <mockk.version>1.13.10</mockk.version>
-        <quarkus.version>3.6.5</quarkus.version>
+        <quarkus.version>3.8.4</quarkus.version>
         <dokka.version>1.9.10</dokka.version>
         <assertj.version>3.25.3</assertj.version>
 
         <!-- This plugin is not compatible with kotlin -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
     </properties>
 
     <scm>


### PR DESCRIPTION
Upgrading to latest quarkus LTS version 3.8.4 and integrating relevant changes from #265 