### PR TITLE
chore(fix): added docs as maven submodule

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,7 +34,9 @@ The extension exposes two annotations:
 
 == Compatibility with Quarkus
 
-Starting with Quarkus `2.8` and above, version `1.1.0` of `quarkus-junit5-mockk` should be used.
+Starting with version `3.8+`, version `3+` of `quarkus-junit5-mockk` should be used.
+If you use a version between ˋ3.0.0`, and before `3.8.0`, version `2.0.0` of `quarkus-junit5-mockk` should be used.
+If you use a version between `2.8` and before `3.0.0`, version `1.1.0` of `quarkus-junit5-mockk` should be used.
 If you use a version before `2.7`, version `1.0.1` of `quarkus-junit5-mockk` should be used.
 
 == Known limitations

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.mockk</groupId>
+        <artifactId>quarkus-junit5-mockk-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-junit5-mockk-docs</artifactId>
+    <name>Quarkus - JUnit 5 - Mockk - Documentation</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>it.ozimov</groupId>
+                <artifactId>yaml-properties-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${project.basedir}/../.github/project.yml</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/modules/ROOT/pages/includes/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../target/asciidoc/generated/config/</directory>
+                                    <include>config.adoc</include>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
     <modules>
         <module>junit5-mockk</module>
+        <module>docs</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
The release build failed because the release workflow contains a maven command agains the doc directory. Added a pom.xml file to the docs directory and added it as a submodule in the main pom.