### PR TITLE
chore: preparing for a new major release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkiverse Mockk Extension
 release:
-  current-version: 3.0.0
+  current-version: 3.0.1
   next-version: 999-SNAPSHOT
 


### PR DESCRIPTION
After updating the jvm version to 17, quarkus to latest LTS 3.8.4 and all other dependency updates, a bump in the major release is warranted.