### PR TITLE
Addressing ecosystem-ci build failures

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -23,7 +23,7 @@ jobs:
     name: "Build against latest Quarkus snapshot"
     runs-on: ubuntu-latest
     # Allow <ADMIN> to manually launch the ecosystem CI in addition to the bots
-    if: github.actor == 'quarkusbot' || github.actor == 'quarkiversebot' || github.actor == 'glefloch'
+    if: github.actor == 'quarkusbot' || github.actor == 'quarkiversebot' || github.actor == 'glefloch' || github.actor == 'janpk'
 
     steps:
       - name: Install yq

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Checkout repo

--- a/junit5-mockk/src/test/kotlin/io/quarkiverse/test/junit/mockk/internal/example/InjectRestClientTest.kt
+++ b/junit5-mockk/src/test/kotlin/io/quarkiverse/test/junit/mockk/internal/example/InjectRestClientTest.kt
@@ -7,12 +7,12 @@ import io.quarkus.test.junit.QuarkusTest
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 import org.eclipse.microprofile.rest.client.inject.RestClient
-import org.jboss.resteasy.annotations.jaxrs.PathParam
 import org.junit.jupiter.api.Test
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 
@@ -49,7 +49,7 @@ class InjectRestClientTest {
         @GET
         @Path("/name/{name}")
         @Produces(MediaType.APPLICATION_JSON)
-        fun getByName(@PathParam name: String): String
+        fun getByName(@PathParam("name") name: String): String
     }
 
 }


### PR DESCRIPTION
it seems that ecosystem-ci builds have been failing for a long time.

* failure on annotation in the rest client test class, switched to using jakarata and not jboss annotation
* after upgrade to java action v4, distribution must be supplied, added temurin
* also added janpk to list of allowed ecosystem-ci manual launch actors